### PR TITLE
User story 54/input timer display

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "@types/node": "^20.12.7"
   },
   "scripts": {
-    "run": "node src/server.js",
+    "run": "nodemon src/server.js",
     "start":"node src/server.js"
   }
 }

--- a/src/public/css/drawStyle.css
+++ b/src/public/css/drawStyle.css
@@ -73,3 +73,16 @@ body {
   text-align: center;
   margin-top: 10px;
 }
+
+#countdown-bar-container {
+  width: 100%;
+  height: 20px;
+  background-color: #f3f3f3;
+}
+
+#countdown-bar {
+  height: 100%;
+  width: 100%;
+  background-color: #ff0000;
+  transition: width 25s linear;
+}

--- a/src/public/html/drawingBoard.html
+++ b/src/public/html/drawingBoard.html
@@ -47,6 +47,9 @@
           <input type="text" id="getInput" placeholder="default value here" />
           <button id="doneButton">Done!</button>
         </div>
+        <div id="countdown-bar-container" style="margin-top: 40px">
+          <div id="countdown-bar"></div>
+        </div>
       </div>
     </div>
     <div id="appLogo">

--- a/src/public/js/drawingBoard.js
+++ b/src/public/js/drawingBoard.js
@@ -17,6 +17,7 @@ let isDrawing = false
 let drawWidth = '2'
 drawWidth = '2'
 let drawColour = 'black'
+const inputTimer = 25
 
 canvas.addEventListener('mousedown', startDrawing, false)
 canvas.addEventListener('mousemove', draw, false)
@@ -112,7 +113,7 @@ function activateInputPrompt(timeout) {
 }
 
 function getPrompt() {
-  activateInputPrompt(15000).then((prompt) => {
+  activateInputPrompt(inputTimer * 1000).then((prompt) => {
     const promptText = document.getElementById('prompt')
     promptText.innerText = prompt
   })

--- a/src/public/js/drawingBoard.js
+++ b/src/public/js/drawingBoard.js
@@ -75,9 +75,16 @@ function activateInputPrompt(timeout) {
     const inputPrompt = document.getElementById('inputPrompt')
     const doneButton = document.getElementById('doneButton')
     const getInput = document.getElementById('getInput')
+    const countdownBar = document.getElementById('countdown-bar')
 
     // Show the inputPrompt
     inputPrompt.style.display = 'block'
+
+    // Start the countdown
+    countdownBar.style.width = '100%'
+    const countdownBarTimer = setTimeout(() => {
+      countdownBar.style.width = '0%'
+    }, 0)
 
     // Set a timeout to hide the inputPrompt
     const timeoutId = setTimeout(() => {
@@ -86,22 +93,23 @@ function activateInputPrompt(timeout) {
     }, timeout)
 
     // Add event listener to doneButton to hide the inputPrompt
-    doneButton.addEventListener('click', inputEntered)
+    doneButton.addEventListener('click', inputDone)
 
     // Add event listener to getInput to hide the inputPrompt when Enter is pressed
     getInput.addEventListener('keydown', (event) => {
       if (event.key === 'Enter') {
-        inputEntered()
+        inputDone()
       }
     })
 
-    function inputEntered() {
-      inputPrompt.style.display = 'none'
-      clearTimeout(timeoutId)
-      inputDone()
-    }
-
     function inputDone() {
+      inputPrompt.style.display = 'none'
+
+      // Reset the countdown bar and timer
+      countdownBar.style.width = '100%'
+      clearTimeout(timeoutId)
+      clearTimeout(countdownBarTimer)
+
       let prompt = getInput.value
       if (prompt == '') {
         prompt = getInput.placeholder

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -57,7 +57,7 @@ test.describe('Testing the input field when the draw page is loaded', () => {
   })
 })
 
-test('testing input field', async ({ page }) => {
+test('input field closes when the done button is pressed', async ({ page }) => {
   await page.goto('http://localhost:4000/draw')
 
   //enter a prompt
@@ -67,6 +67,34 @@ test('testing input field', async ({ page }) => {
   //check if the prompt is displayed
   const prompt = await page.locator('#prompt').innerText()
   expect(prompt).toBe('test prompt')
+})
+test('input field closes when the enter key is pressed', async ({ page }) => {
+  await page.goto('http://localhost:4000/draw')
+
+  //enter a prompt
+  await page.locator('#getInput').fill('test prompt')
+  await page.locator('#getInput').press('Enter')
+
+  //check if the prompt is displayed
+  const prompt = await page.locator('#prompt').innerText()
+  expect(prompt).toBe('test prompt')
+})
+test('input field closes after 25 seconds', async ({ page }) => {
+  await page.goto('http://localhost:4000/draw')
+  const inputTimer = 25
+
+  //enter a prompt
+  await page.locator('#getInput').fill('test prompt')
+
+  // input field does not close after 24 seconds
+  await page.waitForTimeout((inputTimer - 1) * 1000)
+  let isVisible = await page.locator('#getInput').isVisible()
+  expect(isVisible).toBe(true)
+
+  // input field closes after 25 seconds
+  await page.waitForTimeout(1000)
+  isVisible = await page.locator('#getInput').isVisible()
+  expect(isVisible).toBe(false)
 })
 
 test('testing colour change', async ({ page }) => {

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -68,6 +68,7 @@ test('input field closes when the done button is pressed', async ({ page }) => {
   const prompt = await page.locator('#prompt').innerText()
   expect(prompt).toBe('test prompt')
 })
+
 test('input field closes when the enter key is pressed', async ({ page }) => {
   await page.goto('http://localhost:4000/draw')
 
@@ -79,6 +80,7 @@ test('input field closes when the enter key is pressed', async ({ page }) => {
   const prompt = await page.locator('#prompt').innerText()
   expect(prompt).toBe('test prompt')
 })
+
 test('input field closes after 25 seconds', async ({ page }) => {
   await page.goto('http://localhost:4000/draw')
   const inputTimer = 25
@@ -95,6 +97,46 @@ test('input field closes after 25 seconds', async ({ page }) => {
   await page.waitForTimeout(1000)
   isVisible = await page.locator('#getInput').isVisible()
   expect(isVisible).toBe(false)
+})
+
+test('testing the timer bar appears until the prompt is entered', async ({
+  page,
+}) => {
+  await page.goto('http://localhost:4000/draw')
+
+  //check if the timer bar is displayed
+  let timerBar = await page.locator('#countdown-bar').isVisible()
+  expect(timerBar).toBe(true)
+
+  //enter a prompt and click done
+  await page.locator('#getInput').fill('test prompt')
+  await page.locator('#doneButton').click()
+
+  //check if the timer bar is displayed
+  timerBar = await page.locator('#countdown-bar').isVisible()
+  expect(timerBar).toBe(false)
+})
+
+test('testing that the timer bar decreases in width', async ({ page }) => {
+  await page.goto('http://localhost:4000/draw')
+
+  //get the initial width of the timer bar
+  const initialWidth = await page.$eval(
+    '#countdown-bar',
+    (element) => getComputedStyle(element).width
+  )
+
+  //wait for some time
+  await page.waitForTimeout(500)
+
+  //get the width of the timer bar after half a second
+  const laterWidth = await page.$eval(
+    '#countdown-bar',
+    (element) => getComputedStyle(element).width
+  )
+
+  //check if the width of the timer bar has decreased
+  expect(parseInt(laterWidth)).toBeLessThan(parseInt(initialWidth))
 })
 
 test('testing colour change', async ({ page }) => {

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -82,6 +82,7 @@ test('input field closes when the enter key is pressed', async ({ page }) => {
 })
 
 test('input field closes after 25 seconds', async ({ page }) => {
+  test.setTimeout(40000)
   await page.goto('http://localhost:4000/draw')
   const inputTimer = 25
 

--- a/tests/login.spec.js
+++ b/tests/login.spec.js
@@ -53,5 +53,4 @@ test('submitting the login form with wrong input should display an error', async
   expect(
     await page.getByText('Invalid username or password').isVisible()
   ).toBeTruthy()
-  await page.close()
 })

--- a/tests/welcome.spec.js
+++ b/tests/welcome.spec.js
@@ -69,4 +69,5 @@ test('Join button takes you to draw page', async ({ page }) => {
 
   // Check if the current URL is the expected URL
   expect(currentUrl).toBe('http://localhost:4000/draw')
+  page.close()
 })


### PR DESCRIPTION
Added a timer bar for the input, which shows a decrease in time from 25 to 0 seconds
Added tests for the timer bar

One test ensures that the input field closes after 25 seconds, however, this means that the test takes 25 seconds to run, which is very unoptimal. However, I am not sure how to solve this

closes #54 