### PR TITLE
User story 62/draw timer

### DIFF
--- a/src/public/css/drawStyle.css
+++ b/src/public/css/drawStyle.css
@@ -38,6 +38,19 @@ body {
   margin-right: 5px;
 }
 
+.countdown-bar-container {
+  width: 100%;
+  height: 20px;
+  background-color: #f3f3f3;
+}
+
+.countdown-bar {
+  height: 100%;
+  width: 100%;
+  background-color: #ff0000;
+  transition: width 30s linear;
+}
+
 #colour-picker {
   align-self: center;
   margin-left: 5px;
@@ -72,17 +85,4 @@ body {
   font-size: 30px;
   text-align: center;
   margin-top: 10px;
-}
-
-#countdown-bar-container {
-  width: 100%;
-  height: 20px;
-  background-color: #f3f3f3;
-}
-
-#countdown-bar {
-  height: 100%;
-  width: 100%;
-  background-color: #ff0000;
-  transition: width 25s linear;
 }

--- a/src/public/html/drawingBoard.html
+++ b/src/public/html/drawingBoard.html
@@ -53,8 +53,8 @@
           <input type="text" id="getInput" placeholder="default value here" />
           <button id="doneButton">Done!</button>
         </div>
-        <div id="countdown-bar-container" style="margin-top: 40px">
-          <div id="countdown-bar"></div>
+        <div class="countdown-bar-container" style="margin-top: 40px">
+          <div id="inputCountdownBar" class="countdown-bar"></div>
         </div>
       </div>
     </div>
@@ -66,6 +66,9 @@
       />
     </div>
     <div id="prompt">Prompt</div>
+    <div class="countdown-bar-container" style="margin-top: 40px; width: 80%">
+      <div id="drawingCountdownBar" class="countdown-bar"></div>
+    </div>
     <div class="whiteboard">
       <canvas id="canvas"></canvas>
       <div class="tools">

--- a/src/public/js/drawingBoard.js
+++ b/src/public/js/drawingBoard.js
@@ -93,6 +93,7 @@ let endTimeout = function () {}
 
 function submitDrawing() {
   const image = canvas.toDataURL('image/png')
+  stopDrawing({ type: 'mouseout' })
   context.fillRect(0, 0, canvas.width, canvas.height)
 
   endTimeout()
@@ -194,3 +195,9 @@ function startDrawTimer() {
 
 // start the game by getting the user's first prompt
 getPrompt()
+
+/* BUG FIX: 
+The canvas does not get cleared if the user is drawing the moment the timer runs out
+The input timer sometimes does not show up - very inconsistent, I am not sure what causes it
+
+*/

--- a/src/public/js/drawingBoard.js
+++ b/src/public/js/drawingBoard.js
@@ -11,6 +11,15 @@ const multiColourButton = document.getElementById('colour-picker')
 const submitButton = document.getElementById('submit')
 const drawingDisplay = document.getElementById('drawingDisplay')
 
+const inputPrompt = document.getElementById('inputPrompt')
+const doneButton = document.getElementById('doneButton')
+const getInput = document.getElementById('getInput')
+const inputCountdownBar = document.getElementById('inputCountdownBar')
+const drawingCountdownBar = document.getElementById('drawingCountdownBar')
+
+const drawing = document.getElementById('drawing')
+const notDrawing = document.getElementById('notDrawing')
+
 const context = canvas.getContext('2d')
 context.fillStyle = 'white'
 context.fillRect(0, 0, canvas.width, canvas.height)
@@ -21,7 +30,10 @@ drawingDisplay.height = canvas.height / 4
 let isDrawing = false
 let drawWidth = '2'
 let drawColour = 'black'
-const inputTimer = 25
+
+const urlParams = new URLSearchParams(window.location.search)
+const inputTimer = (urlParams.get('inputTimer') || 25) * 1000
+const drawingTimer = (urlParams.get('drawingTimer') || 60) * 1000
 
 canvas.addEventListener('mousedown', startDrawing, false)
 canvas.addEventListener('mousemove', draw, false)
@@ -76,24 +88,19 @@ function stopDrawing(e) {
   }
 }
 
+// stores the timeouts for the drawing bar, so that they can be ended from the submitdrawing function
+let endTimeout = function () {}
+
 function submitDrawing() {
   const image = canvas.toDataURL('image/png')
   context.fillRect(0, 0, canvas.width, canvas.height)
 
-  activateInputPrompt(inputTimer * 1000, image).then((prompt) =>
-    setPrompt(prompt)
-  )
+  endTimeout()
+
+  getPrompt(image)
 }
 
-function activateInputPrompt(timeout, img = null) {
-  const inputPrompt = document.getElementById('inputPrompt')
-  const doneButton = document.getElementById('doneButton')
-  const getInput = document.getElementById('getInput')
-  const countdownBar = document.getElementById('countdown-bar')
-
-  const drawing = document.getElementById('drawing')
-  const notDrawing = document.getElementById('notDrawing')
-
+function activateInputPrompt(img = null) {
   return new Promise((resolve) => {
     // the text displayed changes based on if an image is given (we are reviewing a drawing), or not (it is the start of the game)
     drawing.style.display = img ? 'block' : 'none'
@@ -106,13 +113,14 @@ function activateInputPrompt(timeout, img = null) {
     inputPrompt.style.display = 'block'
 
     // Start the countdown
-    countdownBar.style.width = '100%'
+    inputCountdownBar.style.width = '100%'
+    inputCountdownBar.style.transitionDuration = `${inputTimer}ms`
     const countdownBarTimer = setTimeout(() => {
-      countdownBar.style.width = '0%'
+      inputCountdownBar.style.width = '0%'
     }, 0)
 
     // Set a timeout to hide the inputPrompt
-    const timeoutId = setTimeout(inputDone, timeout)
+    const timeoutId = setTimeout(inputDone, inputTimer)
 
     function checkEnterKey(event) {
       if (event.key === 'Enter') {
@@ -124,7 +132,7 @@ function activateInputPrompt(timeout, img = null) {
       inputPrompt.style.display = 'none'
 
       // Reset the countdown bar and timer
-      countdownBar.style.width = '100%'
+      inputCountdownBar.style.width = '100%'
       clearTimeout(countdownBarTimer)
       clearTimeout(timeoutId)
 
@@ -145,13 +153,42 @@ function activateInputPrompt(timeout, img = null) {
   })
 }
 
-function getPrompt() {
-  activateInputPrompt(inputTimer * 1000).then((prompt) => setPrompt(prompt))
+function getPrompt(image = null) {
+  if (image) {
+    activateInputPrompt(image).then((prompt) => setPrompt(prompt))
+  } else {
+    activateInputPrompt().then((prompt) => setPrompt(prompt))
+  }
 }
 
 function setPrompt(prompt) {
   const promptText = document.getElementById('prompt')
   promptText.innerText = prompt
+  startDrawTimer()
+}
+
+function startDrawTimer() {
+  drawingCountdownBar.style.width = '100%'
+  drawingCountdownBar.style.transitionDuration = `${drawingTimer}ms`
+  const countdownBarTimer = setTimeout(() => {
+    drawingCountdownBar.style.width = '0%'
+  }, 0)
+
+  const countdownBarTimeout = setTimeout(() => {
+    clearTimeout(countdownBarTimer)
+    submitDrawing()
+  }, drawingTimer)
+
+  endTimeout = function () {
+    clearTimeout(countdownBarTimeout)
+    clearTimeout(countdownBarTimer)
+    drawingCountdownBar.style.transition = 'none'
+    drawingCountdownBar.style.width = '100%'
+    // Force a reflow to apply the changes immediately
+    void drawingCountdownBar.offsetWidth
+    // Re-enable the transition
+    drawingCountdownBar.style.transition = ''
+  }
 }
 
 // start the game by getting the user's first prompt

--- a/src/public/js/drawingBoard.js
+++ b/src/public/js/drawingBoard.js
@@ -116,9 +116,11 @@ function activateInputPrompt(img = null) {
     // Start the countdown
     inputCountdownBar.style.width = '100%'
     inputCountdownBar.style.transitionDuration = `${inputTimer}ms`
-    const countdownBarTimer = setTimeout(() => {
-      inputCountdownBar.style.width = '0%'
-    }, 0)
+    requestAnimationFrame(() => {
+      requestAnimationFrame(() => {
+        inputCountdownBar.style.width = '0%'
+      })
+    })
 
     // Set a timeout to hide the inputPrompt
     const timeoutId = setTimeout(inputDone, inputTimer)
@@ -131,11 +133,11 @@ function activateInputPrompt(img = null) {
 
     function inputDone() {
       inputPrompt.style.display = 'none'
+      drawingDisplay.src = ''
 
       // Reset the countdown bar and timer
       inputCountdownBar.style.width = '100%'
       void drawingCountdownBar.offsetWidth // force a reflow to apply the changes immediately
-      clearTimeout(countdownBarTimer)
       clearTimeout(timeoutId)
 
       let prompt = getInput.value
@@ -172,18 +174,19 @@ function setPrompt(prompt) {
 function startDrawTimer() {
   drawingCountdownBar.style.width = '100%'
   drawingCountdownBar.style.transitionDuration = `${drawingTimer}ms`
-  const countdownBarTimer = setTimeout(() => {
-    drawingCountdownBar.style.width = '0%'
-  }, 0)
+  requestAnimationFrame(() => {
+    requestAnimationFrame(() => {
+      drawingCountdownBar.style.width = '0%'
+    })
+  })
 
   const countdownBarTimeout = setTimeout(() => {
-    clearTimeout(countdownBarTimer)
     submitDrawing()
   }, drawingTimer)
 
   endTimeout = function () {
     clearTimeout(countdownBarTimeout)
-    clearTimeout(countdownBarTimer)
+
     drawingCountdownBar.style.transition = 'none'
     drawingCountdownBar.style.width = '100%'
     // Force a reflow to apply the changes immediately
@@ -195,9 +198,3 @@ function startDrawTimer() {
 
 // start the game by getting the user's first prompt
 getPrompt()
-
-/* BUG FIX: 
-The canvas does not get cleared if the user is drawing the moment the timer runs out
-The input timer sometimes does not show up - very inconsistent, I am not sure what causes it
-
-*/

--- a/src/public/js/drawingBoard.js
+++ b/src/public/js/drawingBoard.js
@@ -133,6 +133,7 @@ function activateInputPrompt(img = null) {
 
       // Reset the countdown bar and timer
       inputCountdownBar.style.width = '100%'
+      void drawingCountdownBar.offsetWidth // force a reflow to apply the changes immediately
       clearTimeout(countdownBarTimer)
       clearTimeout(timeoutId)
 

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -81,20 +81,37 @@ test('input field closes when the enter key is pressed', async ({ page }) => {
   expect(prompt).toBe('test prompt')
 })
 
-test('input field closes after 25 seconds', async ({ page }) => {
-  test.setTimeout(40000)
-  await page.goto('http://localhost:4000/draw')
-  const inputTimer = 25
+test('input field closes after a certain amount of time', async ({ page }) => {
+  const inputTimer = 3
 
-  // input field does not close after 24 seconds
-  await page.waitForTimeout((inputTimer - 1) * 1000)
+  await page.goto(`http://localhost:4000/draw?inputTimer=${inputTimer}`)
+
+  // input field does not close after 1.5 seconds before the timer ends
+  await page.waitForTimeout(inputTimer * 1000 - 1500)
   let isVisible = await page.locator('#getInput').isVisible()
   expect(isVisible).toBe(true)
 
-  // input field closes after 25 seconds
-  await page.waitForTimeout(1000)
+  // input field closes after the full time
+  await page.waitForTimeout(1500)
   isVisible = await page.locator('#getInput').isVisible()
   expect(isVisible).toBe(false)
+})
+
+test('the user can draw for a certain amount of time', async ({ page }) => {
+  const drawTimer = 3
+
+  await page.goto(`http://localhost:4000/draw?drawingTimer=${drawTimer}`)
+  await page.locator('#doneButton').click()
+
+  // input field does appear after 1.5 seconds before the timer ends
+  await page.waitForTimeout(drawTimer * 1000 - 1500)
+  let isVisible = await page.locator('#getInput').isVisible()
+  expect(isVisible).toBe(false)
+
+  // input field opens after the full time
+  await page.waitForTimeout(1500)
+  isVisible = await page.locator('#getInput').isVisible()
+  expect(isVisible).toBe(true)
 })
 
 test('testing the timer bar appears until the prompt is entered', async ({
@@ -119,10 +136,12 @@ test.describe('testing that the timer bar decreases in width', () => {
     await page.goto('http://localhost:4000/draw')
   })
 
-  test('for the original prompt entering', async ({ page }) => {
+  test('The input timer bar decreases for the original prompt entering', async ({
+    page,
+  }) => {
     //get the initial width of the timer bar
     const initialWidth = await page.$eval(
-      '#countdown-bar',
+      '#inputCountdownBar',
       (element) => getComputedStyle(element).width
     )
 
@@ -131,7 +150,7 @@ test.describe('testing that the timer bar decreases in width', () => {
 
     //get the width of the timer bar after half a second
     const laterWidth = await page.$eval(
-      '#countdown-bar',
+      '#inputCountdownBar',
       (element) => getComputedStyle(element).width
     )
 
@@ -139,14 +158,16 @@ test.describe('testing that the timer bar decreases in width', () => {
     expect(parseInt(laterWidth)).toBeLessThan(parseInt(initialWidth))
   })
 
-  test('for describing a drawing', async ({ page }) => {
-    // get to teh describe a drawing point
+  test('The input timer bar decreases for describing a drawing', async ({
+    page,
+  }) => {
+    // get to the describe a drawing point
     await page.locator('#doneButton').click()
     await page.locator('#submit').click()
 
     //get the initial width of the timer bar
     const initialWidth = await page.$eval(
-      '#countdown-bar',
+      '#inputCountdownBar',
       (element) => getComputedStyle(element).width
     )
 
@@ -155,7 +176,29 @@ test.describe('testing that the timer bar decreases in width', () => {
 
     //get the width of the timer bar after half a second
     const laterWidth = await page.$eval(
-      '#countdown-bar',
+      '#inputCountdownBar',
+      (element) => getComputedStyle(element).width
+    )
+
+    //check if the width of the timer bar has decreased
+    expect(parseInt(laterWidth)).toBeLessThan(parseInt(initialWidth))
+  })
+  test('The draw timer bar decreases', async ({ page }) => {
+    // get to the describe a drawing point
+    await page.locator('#doneButton').click()
+
+    //get the initial width of the timer bar
+    const initialWidth = await page.$eval(
+      '#drawingCountdownBar',
+      (element) => getComputedStyle(element).width
+    )
+
+    //wait for some time
+    await page.waitForTimeout(500)
+
+    //get the width of the timer bar after half a second
+    const laterWidth = await page.$eval(
+      '#drawingCountdownBar',
       (element) => getComputedStyle(element).width
     )
 

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -120,42 +120,52 @@ test('testing the timer bar appears until the prompt is entered', async ({
   await page.goto('http://localhost:4000/draw')
 
   //check if the timer bar is displayed
-  let timerBar = await page.locator('#countdown-bar').isVisible()
+  let timerBar = await page.locator('#inputCountdownBar').isVisible()
   expect(timerBar).toBe(true)
 
   //enter a prompt and click done
   await page.locator('#doneButton').click()
 
   //check if the timer bar is displayed
-  timerBar = await page.locator('#countdown-bar').isVisible()
+  timerBar = await page.locator('#inputCountdownBar').isVisible()
   expect(timerBar).toBe(false)
 })
 
 test.describe('testing that the timer bar decreases in width', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('http://localhost:4000/draw')
+    await page.goto('http://localhost:4000/draw?inputTimer=50&drawingTimer=60')
   })
+  // The difPercentage part of the test is very inconsistent, it can go from about 1-2.5% for all of them, up to around 10-15%
 
   test('The input timer bar decreases for the original prompt entering', async ({
     page,
   }) => {
     //get the initial width of the timer bar
-    const initialWidth = await page.$eval(
-      '#inputCountdownBar',
-      (element) => getComputedStyle(element).width
+    const initialWidth = parseInt(
+      await page.$eval('#inputCountdownBar', (e) => getComputedStyle(e).width)
     )
+
+    const waitTime = 2000
 
     //wait for some time
-    await page.waitForTimeout(500)
+    await page.waitForTimeout(waitTime)
 
     //get the width of the timer bar after half a second
-    const laterWidth = await page.$eval(
-      '#inputCountdownBar',
-      (element) => getComputedStyle(element).width
+    const laterWidth = parseInt(
+      await page.$eval('#inputCountdownBar', (e) => getComputedStyle(e).width)
     )
 
+    // get the expected decrease in width in seconds
+    const expectedDecrease =
+      ((initialWidth - laterWidth) / initialWidth) * 50 * 1000
+
+    // the difference in percentage must be less than 15%
+    const difPercentage =
+      (Math.abs(expectedDecrease - waitTime) / waitTime) * 100
+
     //check if the width of the timer bar has decreased
-    expect(parseInt(laterWidth)).toBeLessThan(parseInt(initialWidth))
+    expect(laterWidth).toBeLessThan(initialWidth)
+    expect(difPercentage).toBeLessThan(15)
   })
 
   test('The input timer bar decreases for describing a drawing', async ({
@@ -166,44 +176,62 @@ test.describe('testing that the timer bar decreases in width', () => {
     await page.locator('#submit').click()
 
     //get the initial width of the timer bar
-    const initialWidth = await page.$eval(
-      '#inputCountdownBar',
-      (element) => getComputedStyle(element).width
+    const initialWidth = parseInt(
+      await page.$eval('#inputCountdownBar', (e) => getComputedStyle(e).width)
     )
+
+    const waitTime = 2000
 
     //wait for some time
-    await page.waitForTimeout(500)
+    await page.waitForTimeout(waitTime)
 
     //get the width of the timer bar after half a second
-    const laterWidth = await page.$eval(
-      '#inputCountdownBar',
-      (element) => getComputedStyle(element).width
+    const laterWidth = parseInt(
+      await page.$eval('#inputCountdownBar', (e) => getComputedStyle(e).width)
     )
 
+    // get the expected decrease in width in seconds
+    const expectedDecrease =
+      ((initialWidth - laterWidth) / initialWidth) * 50 * 1000
+
+    // the difference in percentage must be less than 15%
+    const difPercentage =
+      (Math.abs(expectedDecrease - waitTime) / waitTime) * 100
+
     //check if the width of the timer bar has decreased
-    expect(parseInt(laterWidth)).toBeLessThan(parseInt(initialWidth))
+    expect(laterWidth).toBeLessThan(initialWidth)
+    expect(difPercentage).toBeLessThan(15)
   })
   test('The draw timer bar decreases', async ({ page }) => {
     // get to the describe a drawing point
     await page.locator('#doneButton').click()
 
     //get the initial width of the timer bar
-    const initialWidth = await page.$eval(
-      '#drawingCountdownBar',
-      (element) => getComputedStyle(element).width
+    const initialWidth = parseInt(
+      await page.$eval('#drawingCountdownBar', (e) => getComputedStyle(e).width)
     )
+
+    const waitTime = 2000
 
     //wait for some time
-    await page.waitForTimeout(500)
+    await page.waitForTimeout(waitTime)
 
     //get the width of the timer bar after half a second
-    const laterWidth = await page.$eval(
-      '#drawingCountdownBar',
-      (element) => getComputedStyle(element).width
+    const laterWidth = parseInt(
+      await page.$eval('#drawingCountdownBar', (e) => getComputedStyle(e).width)
     )
 
+    // get the expected decrease in width in seconds
+    const expectedDecrease =
+      ((initialWidth - laterWidth) / initialWidth) * 60 * 1000
+
+    // the difference in percentage must be less than 15%
+    const difPercentage =
+      (Math.abs(expectedDecrease - waitTime) / waitTime) * 100
+
     //check if the width of the timer bar has decreased
-    expect(parseInt(laterWidth)).toBeLessThan(parseInt(initialWidth))
+    expect(laterWidth).toBeLessThan(initialWidth)
+    expect(difPercentage).toBeLessThan(15)
   })
 })
 

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -132,10 +132,16 @@ test('testing the timer bar appears until the prompt is entered', async ({
 })
 
 test.describe('testing that the timer bar decreases in width', () => {
+  const waitTime = 1000
+  const inputTimer = 25
+  const drawingTimer = 60
+  const percentageAllowed = 10
   test.beforeEach(async ({ page }) => {
-    await page.goto('http://localhost:4000/draw?inputTimer=50&drawingTimer=60')
+    await page.goto(
+      `http://localhost:4000/draw?inputTimer=${inputTimer}&drawingTimer=${drawingTimer}`
+    )
   })
-  // The difPercentage part of the test is very inconsistent, it can go from about 1-2.5% for all of them, up to around 10-15%
+  // The difPercentage part of the test is very inconsistent, and it can go from about 1-2.5% for all of them, up to around 10%
 
   test('The input timer bar decreases for the original prompt entering', async ({
     page,
@@ -144,8 +150,6 @@ test.describe('testing that the timer bar decreases in width', () => {
     const initialWidth = parseInt(
       await page.$eval('#inputCountdownBar', (e) => getComputedStyle(e).width)
     )
-
-    const waitTime = 2000
 
     //wait for some time
     await page.waitForTimeout(waitTime)
@@ -157,15 +161,16 @@ test.describe('testing that the timer bar decreases in width', () => {
 
     // get the expected decrease in width in seconds
     const expectedDecrease =
-      ((initialWidth - laterWidth) / initialWidth) * 50 * 1000
+      ((initialWidth - laterWidth) / initialWidth) * inputTimer * 1000
 
-    // the difference in percentage must be less than 15%
+    // the difference in percentage must be less than a certain percentage
     const difPercentage =
       (Math.abs(expectedDecrease - waitTime) / waitTime) * 100
+    console.log(difPercentage)
 
     //check if the width of the timer bar has decreased
     expect(laterWidth).toBeLessThan(initialWidth)
-    expect(difPercentage).toBeLessThan(15)
+    expect(difPercentage).toBeLessThan(percentageAllowed)
   })
 
   test('The input timer bar decreases for describing a drawing', async ({
@@ -180,8 +185,6 @@ test.describe('testing that the timer bar decreases in width', () => {
       await page.$eval('#inputCountdownBar', (e) => getComputedStyle(e).width)
     )
 
-    const waitTime = 2000
-
     //wait for some time
     await page.waitForTimeout(waitTime)
 
@@ -192,15 +195,16 @@ test.describe('testing that the timer bar decreases in width', () => {
 
     // get the expected decrease in width in seconds
     const expectedDecrease =
-      ((initialWidth - laterWidth) / initialWidth) * 50 * 1000
+      ((initialWidth - laterWidth) / initialWidth) * inputTimer * 1000
 
-    // the difference in percentage must be less than 15%
+    // the difference in percentage must be less than a certain percentage
     const difPercentage =
       (Math.abs(expectedDecrease - waitTime) / waitTime) * 100
+    console.log(difPercentage)
 
     //check if the width of the timer bar has decreased
     expect(laterWidth).toBeLessThan(initialWidth)
-    expect(difPercentage).toBeLessThan(15)
+    expect(difPercentage).toBeLessThan(percentageAllowed)
   })
   test('The draw timer bar decreases', async ({ page }) => {
     // get to the describe a drawing point
@@ -210,8 +214,6 @@ test.describe('testing that the timer bar decreases in width', () => {
     const initialWidth = parseInt(
       await page.$eval('#drawingCountdownBar', (e) => getComputedStyle(e).width)
     )
-
-    const waitTime = 2000
 
     //wait for some time
     await page.waitForTimeout(waitTime)
@@ -223,15 +225,16 @@ test.describe('testing that the timer bar decreases in width', () => {
 
     // get the expected decrease in width in seconds
     const expectedDecrease =
-      ((initialWidth - laterWidth) / initialWidth) * 60 * 1000
+      ((initialWidth - laterWidth) / initialWidth) * drawingTimer * 1000
 
-    // the difference in percentage must be less than 15%
+    // the difference in percentage must be less than a certain percentage
     const difPercentage =
       (Math.abs(expectedDecrease - waitTime) / waitTime) * 100
+    console.log(difPercentage)
 
     //check if the width of the timer bar has decreased
     expect(laterWidth).toBeLessThan(initialWidth)
-    expect(difPercentage).toBeLessThan(15)
+    expect(difPercentage).toBeLessThan(percentageAllowed)
   })
 })
 


### PR DESCRIPTION
The drawing phase has a timer that displays how much time is left to draw
The drawing period ends when this timer ends, and goes to the describe a drawing phase
The time given for both phases can be changed from URL parameters, in order to accommodate better testing, and possible game modes in the future (eg: a quick-draw mode)
Tests were written
Earlier tests on the timer bar length decreasing were improved to get an approximate amount that they decreased


closes #62 