### PR TITLE
bug fix 82/game breaking

### DIFF
--- a/src/public/js/drawingBoard.js
+++ b/src/public/js/drawingBoard.js
@@ -333,14 +333,14 @@ function activateInputPrompt(img = null) {
 
   // const timeoutId = setTimeout(submitPrompt, inputTimer)
 
-  function checkEnterKey(event) {
-    if (event.key === 'Enter') {
-      submitPrompt()
-    }
-  }
+  // function checkEnterKey(event) {
+  //   if (event.key === 'Enter') {
+  //     submitPrompt()
+  //   }
+  // }
 
-  doneButton.addEventListener('click', submitPrompt)
-  getInput.addEventListener('keydown', checkEnterKey)
+  // doneButton.addEventListener('click', submitPrompt)
+  // getInput.addEventListener('keydown', checkEnterKey)
 
   // endTimeout = function () {
   //   clearTimeout(timeoutId)

--- a/src/server.js
+++ b/src/server.js
@@ -93,6 +93,7 @@ io.on('connection', (socket) => {
       return
     }
 
+    room.allJoined = true // this is true when all people have joined the gameroom, to discern a websocket disconnect from a user leaving the game
     for (const entry of room.todo) {
       const { roomId, prompt, socketID } = entry
 
@@ -221,6 +222,10 @@ io.on('connection', (socket) => {
       if (room.gameStarted) {
         room.maxMembers -= 1
         delete publicRooms[currentRoom]
+      }
+
+      if (room.allJoined) {
+        room.gameSize -= 1
       }
 
       if (room.members.length === 0) {


### PR DESCRIPTION
The game does not break, even if someone presses done before others are loaded
The websocket stores the prompt until the number of members in the gameroom is correct
When someone leaves a gameroom, the number of members updates (* if 3 people are in the game and one leaves, this does not stop the game, which must be fixed)
Moreover, when someone leaves a game, there are still 4 places in the grid, so the other is replaced with null


closes #82 