### PR TITLE
bug 93/sign in not working

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -3,6 +3,7 @@ const bodyParser = require('body-parser')
 const session = require('express-session')
 const pgSession = require('connect-pg-simple')(session)
 const Router = require('./routes/router')
+const welcomeController = require('./controller/welcomeController')
 
 const app = express()
 
@@ -29,6 +30,8 @@ app.use(
 )
 
 app.use('/', Router)
+
+app.use(welcomeController.waitForSession)
 
 app.all('*', (req, res, next) => {
   res.redirect('/')

--- a/src/controller/userController.js
+++ b/src/controller/userController.js
@@ -50,7 +50,15 @@ exports.guest = async (req, res) => {
     id: -1,
     username: req.query.nickname,
   }
-  return res.redirect('/landing')
+  req.session.save((err) => {
+    if (err) {
+      // handle error
+      console.log(err)
+      res.status(500).send('An error occurred while saving the session')
+    } else {
+      return res.redirect('/landing')
+    }
+  })
 }
 
 exports.logout = async (req, res) => {

--- a/src/controller/welcomeController.js
+++ b/src/controller/welcomeController.js
@@ -8,6 +8,23 @@ exports.welcome = async (req, res) => {
   res.sendFile(path.join(__dirname, '../public/html', 'welcome.html'))
 }
 
+exports.waitForSession = (req, res, next) => {
+  if (!req.session.isLoaded) {
+    req.session.reload(function (err) {
+      if (err) {
+        // handle error
+        console.log(err)
+        res.status(500).send('An error occurred while reloading the session')
+      } else {
+        req.session.isLoaded = true
+        next()
+      }
+    })
+  } else {
+    next()
+  }
+}
+
 exports.landing = async (req, res) => {
   if (req.session.user) {
     res.sendFile(

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -6,15 +6,6 @@ async function navigateToGame(context) {
   await page1.getByRole('button', { name: 'Continue as Guest' }).click()
   await page1.getByPlaceholder('Enter your nickname').fill('test name 1')
   await page1.getByRole('button', { name: 'Join' }).click()
-  let signInButton = await page1.getByRole('button', {
-    name: 'Continue as Guest',
-    timeout: 500,
-  })
-  while (signInButton && (await signInButton.isVisible())) {
-    await signInButton.click()
-    await page1.getByPlaceholder('Enter your nickname').fill('test name 1')
-    await page1.getByRole('button', { name: 'Join' }).click()
-  }
   await page1.getByRole('button', { name: 'Create Public Game' }).click()
 
   const page2 = await context.newPage()
@@ -23,15 +14,6 @@ async function navigateToGame(context) {
   await page2.getByPlaceholder('Enter your nickname').fill('test name 2')
   await page2.getByRole('button', { name: 'Join' }).click()
   await page2.getByRole('button', { name: 'Join Public Game' }).click()
-  signInButton = await page2.getByRole('button', {
-    name: 'Continue as Guest',
-    timeout: 500,
-  })
-  while (signInButton && (await signInButton.isVisible())) {
-    await signInButton.click()
-    await page2.getByPlaceholder('Enter your nickname').fill('test name 1')
-    await page2.getByRole('button', { name: 'Join' }).click()
-  }
   await page2.getByRole('button', { name: /^Join$/ }).click()
 
   const page3 = await context.newPage()
@@ -40,15 +22,6 @@ async function navigateToGame(context) {
   await page3.getByPlaceholder('Enter your nickname').fill('test name 3')
   await page3.getByRole('button', { name: 'Join' }).click()
   await page3.getByRole('button', { name: 'Join Public Game' }).click()
-  signInButton = await page3.getByRole('button', {
-    name: 'Continue as Guest',
-    timeout: 500,
-  })
-  while (signInButton && (await signInButton.isVisible())) {
-    await signInButton.click()
-    await page3.getByPlaceholder('Enter your nickname').fill('test name 1')
-    await page3.getByRole('button', { name: 'Join' }).click()
-  }
   await page3.getByRole('button', { name: /^Join$/ }).click()
 
   await page1.getByRole('button', { name: 'Start Game' }).click()

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -3,66 +3,28 @@ const { test, expect } = require('@playwright/test')
 async function navigateToGame(context) {
   const page1 = await context.newPage()
   await page1.goto('http://localhost:4000/')
-
-  await page1.getByRole('button', { name: 'Sign In' }).click()
-  await page1.getByLabel('Username:').click()
-  await page1.getByLabel('Username:').fill('test')
-  await page1.getByLabel('Password:').click()
-  await page1.getByLabel('Password:').fill('test')
-  await page1
-    .locator('#loginForm')
-    .getByRole('button', { name: 'Login' })
-    .click()
-
-  let signInButton = await page1.getByRole('button', {
-    name: 'Sign In',
-    timeout: 500,
-  })
-
-  while (signInButton && (await signInButton.isVisible())) {
-    await signInButton.click()
-    await page1.getByLabel('Username:').click()
-    await page1.getByLabel('Username:').fill('test')
-    await page1.getByLabel('Password:').click()
-    await page1.getByLabel('Password:').fill('test')
-    await page1
-      .locator('#loginForm')
-      .getByRole('button', { name: 'Login' })
-      .click()
-    signInButton = await page1.getByRole('button', { name: 'Sign In' })
-  }
-
+  await page1.getByRole('button', { name: 'Continue as Guest' }).click()
+  await page1.getByPlaceholder('Enter your nickname').fill('test name 1')
+  await page1.getByRole('button', { name: 'Join' }).click()
   await page1.getByRole('button', { name: 'Create Public Game' }).click()
 
   const page2 = await context.newPage()
   await page2.goto('http://localhost:4000/')
-  await page2.getByRole('button', { name: 'Sign In' }).click()
-  await page2.getByLabel('Username:').click()
-  await page2.getByLabel('Username:').fill('test')
-  await page2.getByLabel('Password:').click()
-  await page2.getByLabel('Password:').fill('test')
-  await page2
-    .locator('#loginForm')
-    .getByRole('button', { name: 'Login' })
-    .click()
+  await page2.getByRole('button', { name: 'Continue as Guest' }).click()
+  await page2.getByPlaceholder('Enter your nickname').fill('test name 2')
+  await page2.getByRole('button', { name: 'Join' }).click()
   await page2.getByRole('button', { name: 'Join Public Game' }).click()
   await page2.getByRole('button', { name: /^Join$/ }).click()
 
   const page3 = await context.newPage()
   await page3.goto('http://localhost:4000/')
-  await page3.getByRole('button', { name: 'Sign In' }).click()
-  await page3.getByLabel('Username:').click()
-  await page3.getByLabel('Username:').fill('test')
-  await page3.getByLabel('Password:').click()
-  await page3.getByLabel('Password:').fill('test')
-  await page3
-    .locator('#loginForm')
-    .getByRole('button', { name: 'Login' })
-    .click()
+  await page3.getByRole('button', { name: 'Continue as Guest' }).click()
+  await page3.getByPlaceholder('Enter your nickname').fill('test name 3')
+  await page3.getByRole('button', { name: 'Join' }).click()
   await page3.getByRole('button', { name: 'Join Public Game' }).click()
   await page3.getByRole('button', { name: /^Join$/ }).click()
-  await page1.getByRole('button', { name: 'Start Game' }).click()
 
+  await page1.getByRole('button', { name: 'Start Game' }).click()
   return { page1, page2, page3 }
 }
 

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -6,6 +6,15 @@ async function navigateToGame(context) {
   await page1.getByRole('button', { name: 'Continue as Guest' }).click()
   await page1.getByPlaceholder('Enter your nickname').fill('test name 1')
   await page1.getByRole('button', { name: 'Join' }).click()
+  let signInButton = await page1.getByRole('button', {
+    name: 'Continue as Guest',
+    timeout: 500,
+  })
+  while (signInButton && (await signInButton.isVisible())) {
+    await signInButton.click()
+    await page1.getByPlaceholder('Enter your nickname').fill('test name 1')
+    await page1.getByRole('button', { name: 'Join' }).click()
+  }
   await page1.getByRole('button', { name: 'Create Public Game' }).click()
 
   const page2 = await context.newPage()
@@ -14,6 +23,15 @@ async function navigateToGame(context) {
   await page2.getByPlaceholder('Enter your nickname').fill('test name 2')
   await page2.getByRole('button', { name: 'Join' }).click()
   await page2.getByRole('button', { name: 'Join Public Game' }).click()
+  signInButton = await page2.getByRole('button', {
+    name: 'Continue as Guest',
+    timeout: 500,
+  })
+  while (signInButton && (await signInButton.isVisible())) {
+    await signInButton.click()
+    await page2.getByPlaceholder('Enter your nickname').fill('test name 1')
+    await page2.getByRole('button', { name: 'Join' }).click()
+  }
   await page2.getByRole('button', { name: /^Join$/ }).click()
 
   const page3 = await context.newPage()
@@ -22,6 +40,15 @@ async function navigateToGame(context) {
   await page3.getByPlaceholder('Enter your nickname').fill('test name 3')
   await page3.getByRole('button', { name: 'Join' }).click()
   await page3.getByRole('button', { name: 'Join Public Game' }).click()
+  signInButton = await page3.getByRole('button', {
+    name: 'Continue as Guest',
+    timeout: 500,
+  })
+  while (signInButton && (await signInButton.isVisible())) {
+    await signInButton.click()
+    await page3.getByPlaceholder('Enter your nickname').fill('test name 1')
+    await page3.getByRole('button', { name: 'Join' }).click()
+  }
   await page3.getByRole('button', { name: /^Join$/ }).click()
 
   await page1.getByRole('button', { name: 'Start Game' }).click()


### PR DESCRIPTION
The issue happened as the redirect acted faster than saving the session in req.session, and so middleware was added to ensure the req object is reloaded
Test code was simplified by removing earlier test to retry when sign in did not work
Test code was simplified to use guest user instead of signing in with test account

closes #93 