### PR TITLE
moved history button and fixed redirect

### DIFF
--- a/src/public/css/landingPageStyle.css
+++ b/src/public/css/landingPageStyle.css
@@ -60,6 +60,12 @@ button {
   font-size: 16px;
 }
 
+#historyButton {
+  width: 100%; /* Ensures the div takes full width of the container */
+  margin-top: 20px; /* Adds space above the History button */
+  text-align: center; /* Centers the button */
+}
+
 /* Hover effect for buttons */
 button:hover {
   background-color: #45a049;

--- a/src/public/html/drawingBoard.html
+++ b/src/public/html/drawingBoard.html
@@ -193,7 +193,6 @@
     </div>
   
 
-    <button onclick="window.location.href='/history';" style="position: fixed; bottom: 50px; right: 10px;">History</button>
     <button onclick="window.location.href='/logout';" style="position: fixed; bottom: 10px; right: 10px;">Logout</button>
     <script src=”https://code.jquery.com/jquery-3.2.1.slim.min.js”
     integrity=”sha384-KJ3o2DKtIkvYIK3UENzmM7KCkRr/rE9/Qpg6aAZGJwFDMVNA/GpGFF93hXpG5KkN”

--- a/src/public/html/landingPage.html
+++ b/src/public/html/landingPage.html
@@ -23,6 +23,9 @@
       <button id="createPublicRoom">Create Public Game</button>
       <button id="joinRoom">Join Private Game</button>
       <button id="joinPublicRoom">Join Public Game</button>
+      <div id="historyButton">
+        <button onclick="window.location.href='/history';">History</button>
+      </div>
 
       <div id="roomInfo" style="display: none">
         <p>Room ID: <span id="roomId"></span></p>

--- a/src/public/js/history.js
+++ b/src/public/js/history.js
@@ -194,7 +194,7 @@ document.addEventListener('DOMContentLoaded', function () {
   })
 
   backButton.addEventListener('click', () => {
-    window.location.href = '/draw'
+    window.location.href = '/landing'
   })
 
   fetchGames().then((games) => {


### PR DESCRIPTION
Moved the history button to the landing page, so one would not have to leave an active game to view history.
Fixed the "Back Home" button so it redirects back to the landing page and not the draw page. 
Fixed the styling of the history button to match the rest of the page.

closes #25 