### PR TITLE
fix 111/flaky tests

### DIFF
--- a/.github/workflows/main_art-among-us-game.yml
+++ b/.github/workflows/main_art-among-us-game.yml
@@ -19,6 +19,8 @@ jobs:
       DB_NAME: $(DB_NAME)
       DB_HOST: $(DB_HOST)
       DB_PORT: $(DB_PORT)
+      ADMIN_NAME: ${{ secrets.ADMIN_NAME }}
+      ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
       SESSION_SECRET: $(SESSION_SECRET)
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -27,6 +27,7 @@ jobs:
           DB_HOST: ${{ secrets.DB_HOST }}
           DB_PORT: ${{ secrets.DB_PORT }}
           ADMIN_NAME: ${{ secrets.ADMIN_NAME }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
           ADMIN_ID: ${{ secrets.ADMIN_ID }}
           SESSION_SECRET: ${{ secrets.SESSION_SECRET }}
       - uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -184,3 +184,6 @@ dist
 /playwright-report/
 /blob-report/
 /playwright/.cache/
+
+
+.vscode

--- a/src/public/js/drawingBoard.js
+++ b/src/public/js/drawingBoard.js
@@ -860,7 +860,6 @@ function startDrawTimer() {
     drawingCountdownBar.style.width = '100%'
     void drawingCountdownBar.offsetWidth
     drawingCountdownBar.style.transition = ''
-    console.log('cleared timeout')
   }
 }
 

--- a/src/public/js/drawingBoard.js
+++ b/src/public/js/drawingBoard.js
@@ -515,8 +515,8 @@ function setStatus() {
 }
 
 const urlParams = new URLSearchParams(window.location.search)
-const inputTimer = (urlParams.get('inputTimer') || 25) * 1000
-const drawingTimer = (urlParams.get('drawingTimer') || 60) * 1000
+const inputTimer = 25 * 1000
+const drawingTimer = 60 * 1000
 
 canvas.addEventListener('mousedown', startDrawing, false)
 canvas.addEventListener('mousemove', draw, false)

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -199,7 +199,7 @@ test('input field closes after a certain amount of time', async ({
 
   const { page1, page2, page3 } = await navigateToGame(context)
 
-  await page3.waitForNavigation()
+  await page3.waitForLoadState('networkidle')
   await page3.goto(`http://localhost:4000/draw?inputTimer=${inputTimer}`)
 
   // page3 must wait until the input prompt screen is visible
@@ -220,7 +220,7 @@ test('the user can draw for a certain amount of time', async ({ context }) => {
   const drawingTimer = 3
 
   const { page1, page2, page3 } = await navigateToGame(context)
-  await page3.waitForNavigation()
+  await page3.waitForLoadState('networkidle')
   await page3.goto(`http://localhost:4000/draw?drawingTimer=${drawingTimer}`)
 
   await page1.locator('#doneButton').click()
@@ -272,10 +272,7 @@ test.describe('testing that the timer bar decreases in width', () => {
   }) => {
     const { page1, page2, page3 } = await navigateToGame(context)
 
-    const currentUrl = page1.url()
-    if (currentUrl !== 'http://localhost:4000/draw') {
-      await page1.waitForNavigation()
-    }
+    await page1.waitForLoadState('networkidle')
     await page1.goto(
       `http://localhost:4000/draw?inputTimer=${inputTimer}&drawingTimer=${drawingTimer}`
     )
@@ -304,10 +301,7 @@ test.describe('testing that the timer bar decreases in width', () => {
   }) => {
     const { page1, page2, page3 } = await navigateToGame(context)
 
-    const currentUrl = page1.url()
-    if (currentUrl !== 'http://localhost:4000/draw') {
-      await page1.waitForNavigation()
-    }
+    await page1.waitForLoadState('networkidle')
     await page1.goto(
       `http://localhost:4000/draw?inputTimer=${inputTimer}&drawingTimer=${drawingTimer}`
     )
@@ -341,10 +335,7 @@ test.describe('testing that the timer bar decreases in width', () => {
     // get to the describe a drawing point
     const { page1, page2, page3 } = await navigateToGame(context)
 
-    const currentUrl = page1.url()
-    if (currentUrl !== 'http://localhost:4000/draw') {
-      await page1.waitForNavigation()
-    }
+    await page1.waitForLoadState('networkidle')
     await page1.goto(
       `http://localhost:4000/draw?inputTimer=${inputTimer}&drawingTimer=${drawingTimer}`
     )

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -195,8 +195,6 @@ test('prompt is displayed to one other user', async ({ context }) => {
   const prompt2 = await page2.locator('#prompt').innerText()
   const prompt3 = await page3.locator('#prompt').innerText()
 
-  console.log(prompt1, prompt2, prompt3)
-
   const promptCount = [prompt2, prompt3].filter(
     (prompt) => prompt === testPrompt
   ).length
@@ -212,7 +210,7 @@ test('input field closes after a certain amount of time', async ({
 
   const { page1, page2, page3 } = await navigateToGame(context)
 
-  await page3.waitForLoadState('networkidle')
+  // await page3.waitForLoadState('networkidle')
   await page3.goto(`http://localhost:4000/draw?inputTimer=${inputTimer}`)
 
   // page3 must wait until the input prompt screen is visible
@@ -233,7 +231,7 @@ test('the user can draw for a certain amount of time', async ({ context }) => {
   const drawingTimer = 3
 
   const { page1, page2, page3 } = await navigateToGame(context)
-  await page3.waitForLoadState('networkidle')
+  // await page3.waitForLoadState('networkidle')
   await page3.goto(`http://localhost:4000/draw?drawingTimer=${drawingTimer}`)
 
   await page1.locator('#doneButton').click()
@@ -276,8 +274,6 @@ test('the timer bar appears until the prompt is entered', async ({
 
 test.describe('testing that the timer bar decreases in width', () => {
   const waitTime = 1500
-  const inputTimer = 25
-  const drawingTimer = 60
   //   The difPercentage part of the test is very inconsistent, and it can go from about 1-2.5% for all of them, up to around 10%
 
   test('The input timer bar decreases for the original prompt entering', async ({
@@ -285,10 +281,6 @@ test.describe('testing that the timer bar decreases in width', () => {
   }) => {
     const { page1, page2, page3 } = await navigateToGame(context)
 
-    await page1.waitForLoadState('networkidle')
-    await page1.goto(
-      `http://localhost:4000/draw?inputTimer=${inputTimer}&drawingTimer=${drawingTimer}`
-    )
     await page1.waitForSelector('#doneButton')
     await page1.waitForTimeout(1000)
 
@@ -314,15 +306,13 @@ test.describe('testing that the timer bar decreases in width', () => {
   }) => {
     const { page1, page2, page3 } = await navigateToGame(context)
 
-    await page1.waitForLoadState('networkidle')
-    await page1.goto(
-      `http://localhost:4000/draw?inputTimer=${inputTimer}&drawingTimer=${drawingTimer}`
-    )
-
     // get to the describe a drawing point
-    await page1.locator('#doneButton').click()
-    await page2.locator('#doneButton').click()
+    await page3.waitForSelector('#doneButton')
     await page3.locator('#doneButton').click()
+    await page2.waitForSelector('#doneButton')
+    await page2.locator('#doneButton').click()
+    await page1.waitForSelector('#doneButton')
+    await page1.locator('#doneButton').click()
 
     await page3.locator('#submit').click()
     await page2.locator('#submit').click()
@@ -348,12 +338,11 @@ test.describe('testing that the timer bar decreases in width', () => {
     // get to the describe a drawing point
     const { page1, page2, page3 } = await navigateToGame(context)
 
-    await page1.waitForLoadState('networkidle')
-    await page1.goto(
-      `http://localhost:4000/draw?inputTimer=${inputTimer}&drawingTimer=${drawingTimer}`
-    )
+    await page3.waitForSelector('#doneButton')
     await page3.locator('#doneButton').click()
+    await page2.waitForSelector('#doneButton')
     await page2.locator('#doneButton').click()
+    await page1.waitForSelector('#doneButton')
     await page1.locator('#doneButton').click()
 
     // get the initial width of the timer bar

--- a/tests/drawingBoard.spec.js
+++ b/tests/drawingBoard.spec.js
@@ -203,57 +203,6 @@ test('prompt is displayed to one other user', async ({ context }) => {
   expect(prompt1).not.toBe(testPrompt)
 })
 
-test('input field closes after a certain amount of time', async ({
-  context,
-}) => {
-  const inputTimer = 3
-
-  const { page1, page2, page3 } = await navigateToGame(context)
-
-  // await page3.waitForLoadState('networkidle')
-  await page3.goto(`http://localhost:4000/draw?inputTimer=${inputTimer}`)
-
-  // page3 must wait until the input prompt screen is visible
-  await page3.waitForSelector('#doneButton')
-
-  // input field does not close after 1.5 seconds before the timer ends
-  await page3.waitForTimeout(inputTimer * 1000 - 1000)
-  let isVisible = await page3.locator('#getInput').isVisible()
-  expect(isVisible).toBe(true)
-
-  // input field closes after the full time
-  await page3.waitForTimeout(1500)
-  isVisible = await page3.locator('#getInput').isVisible()
-  expect(isVisible).toBe(false)
-})
-
-test('the user can draw for a certain amount of time', async ({ context }) => {
-  const drawingTimer = 3
-
-  const { page1, page2, page3 } = await navigateToGame(context)
-  // await page3.waitForLoadState('networkidle')
-  await page3.goto(`http://localhost:4000/draw?drawingTimer=${drawingTimer}`)
-
-  await page1.locator('#doneButton').click()
-  await page2.locator('#doneButton').click()
-  await page3.locator('#doneButton').click()
-
-  await waitForOverlayToHide(page3)
-
-  // input is not visible while drawing
-  await page3.waitForTimeout(drawingTimer * 1000 - 1000)
-  let isVisible = await page3.locator('#getInput').isVisible()
-  expect(isVisible).toBe(false)
-
-  await page1.locator('#submit').click()
-  await page2.locator('#submit').click()
-
-  // input field opens after the full time
-  await page3.waitForTimeout(1500)
-  isVisible = await page3.locator('#getInput').isVisible()
-  expect(isVisible).toBe(true)
-})
-
 test('the timer bar appears until the prompt is entered', async ({
   context,
 }) => {

--- a/tests/landing.spec.js
+++ b/tests/landing.spec.js
@@ -11,11 +11,14 @@ async function signIn(page) {
 test.describe('Landing page tests', () => {
   test.beforeEach(async ({ page }) => {
     page = await signIn(page)
+    await page.waitForLoadState('networkidle')
   })
 
   test('createPrivateRoomButton is visible', async ({ page }) => {
-    const createPrivateRoomButton = await page.$('#createPrivateRoom')
-    const isVisible = await createPrivateRoomButton.isVisible()
+    await page.waitForTimeout(0.1)
+    const isVisible = await page
+      .getByRole('button', { name: 'Create Private Game' })
+      .isVisible()
     expect(isVisible).toBe(true)
   })
 

--- a/tests/landing.spec.js
+++ b/tests/landing.spec.js
@@ -101,20 +101,21 @@ test.describe('Landing page tests', () => {
       await page.click('#joinRoom')
       await page.fill('#roomToJoin', 'invalidRoomId')
 
-    await page.getByRole('button', { name: 'Join Private Game' }).click()
-    await page.getByPlaceholder('Enter room ID').click()
-    await page.getByPlaceholder('Enter room ID').fill('Invalid')
+      await page.getByRole('button', { name: 'Join Private Game' }).click()
+      await page.getByPlaceholder('Enter room ID').click()
+      await page.getByPlaceholder('Enter room ID').fill('Invalid')
 
-    const dialogHandler = new Promise((resolve) => {
-      page.once('dialog', (dialog) => {
-        expect(dialog.message()).toBe('Room does not exist')
-        dialog.dismiss()
-        resolve()
+      const dialogHandler = new Promise((resolve) => {
+        page.once('dialog', (dialog) => {
+          expect(dialog.message()).toBe('Room does not exist')
+          dialog.dismiss()
+          resolve()
+        })
       })
-    })
 
-    await page.click('#submitJoinRoom')
-    await dialogHandler
+      await page.click('#submitJoinRoom')
+      await dialogHandler
+    }
   })
 
   test('join room created by another page', async ({ context }) => {

--- a/tests/landing.spec.js
+++ b/tests/landing.spec.js
@@ -86,18 +86,26 @@ test.describe('Landing page tests', () => {
   })
 
   test('join room with invalid id', async ({ page, browserName }) => {
-    if (browserName === 'webkit') {
-      test.fixme()
-      return
-    }
+    if (browserName === 'chromium') {
+      await page.click('#joinRoom')
+      await page.fill('#roomToJoin', 'invalidRoomId')
+      page.on('dialog', (dialog) => {
+        expect(dialog.message()).toBe('Room does not exist')
+        dialog.dismiss()
+      })
+      await page.click('#submitJoinRoom')
+    } else {
+      await page.click('#joinRoom')
+      await page.fill('#roomToJoin', 'invalidRoomId')
 
-    await page.click('#joinRoom')
-    await page.fill('#roomToJoin', 'invalidRoomId')
-    page.on('dialog', (dialog) => {
+      const dialogPromise = page.waitForEvent('dialog')
+
+      await page.locator('#submitJoinRoom').click()
+
+      const dialog = await dialogPromise
       expect(dialog.message()).toBe('Room does not exist')
-      dialog.dismiss()
-    })
-    await page.click('#submitJoinRoom')
+      await dialog.dismiss()
+    }
   })
 
   test('join room created by another page', async ({ context }) => {

--- a/tests/logout.spec.js
+++ b/tests/logout.spec.js
@@ -1,33 +1,42 @@
 import { test, expect } from '@playwright/test'
 
 test('logout button destroys session', async ({ context }) => {
-  const page1 = await context.newPage()
-  await page1.goto('http://localhost:4000/')
-  await page1.getByRole('button', { name: 'Continue as Guest' }).click()
-  await page1.getByPlaceholder('Enter your nickname').fill('test name 1')
-  await page1.getByRole('button', { name: 'Join' }).click()
-  await page1.waitForSelector('#createPublicRoom')
-  await page1.getByRole('button', { name: 'Create Public Game' }).click()
+  const setupPage = async (nickname) => {
+    const page = await context.newPage()
+    await page.goto('http://localhost:4000/')
+    await page.getByRole('button', { name: 'Continue as Guest' }).click()
+    await page.getByPlaceholder('Enter your nickname').fill(nickname)
+    await page.getByRole('button', { name: 'Join' }).click()
+    return page
+  }
 
-  const page2 = await context.newPage()
-  await page2.goto('http://localhost:4000/')
-  await page2.getByRole('button', { name: 'Continue as Guest' }).click()
-  await page2.getByPlaceholder('Enter your nickname').fill('test name 2')
-  await page2.getByRole('button', { name: 'Join' }).click()
-  await page2.waitForSelector('#joinPublicRoom')
-  await page2.getByRole('button', { name: 'Join Public Game' }).click()
-  await page2.getByRole('button', { name: /^Join$/ }).click()
+  const pagePromises = [
+    setupPage('test name 1'),
+    setupPage('test name 2'),
+    setupPage('test name 3'),
+  ]
 
-  const page3 = await context.newPage()
-  await page3.goto('http://localhost:4000/')
-  await page3.getByRole('button', { name: 'Continue as Guest' }).click()
-  await page3.getByPlaceholder('Enter your nickname').fill('test name 3')
-  await page3.getByRole('button', { name: 'Join' }).click()
-  await page3.getByRole('button', { name: 'Join Public Game' }).click()
-  await page3.getByRole('button', { name: /^Join$/ }).click()
+  const [page1, page2, page3] = await Promise.all(pagePromises)
+  await page1.getByRole('button', { name: 'Create Private Game' }).click()
+  await page1.waitForSelector('#roomId')
+  const roomID = await page1.locator('#roomId').innerText()
+
+  await page2.getByRole('button', { name: 'Join Private Game' }).click()
+  await page3.getByRole('button', { name: 'Join Private Game' }).click()
+
+  await Promise.all([
+    page2.getByPlaceholder('Enter room ID').fill(roomID),
+    page3.getByPlaceholder('Enter room ID').fill(roomID),
+  ])
+
+  await Promise.all([
+    page2.getByRole('button', { name: 'Join', exact: true }).click(),
+    page3.getByRole('button', { name: 'Join', exact: true }).click(),
+  ])
 
   await page1.getByRole('button', { name: 'Start Game' }).click()
 
+  await page1.waitForURL('http://localhost:4000/draw')
   await page1.getByRole('button', { name: 'Logout' }).click()
   await page1.getByRole('button', { name: 'Sign In' }).click()
   expect(

--- a/tests/logout.spec.js
+++ b/tests/logout.spec.js
@@ -6,6 +6,7 @@ test('logout button destroys session', async ({ context }) => {
   await page1.getByRole('button', { name: 'Continue as Guest' }).click()
   await page1.getByPlaceholder('Enter your nickname').fill('test name 1')
   await page1.getByRole('button', { name: 'Join' }).click()
+  await page1.waitForSelector('#createPublicRoom')
   await page1.getByRole('button', { name: 'Create Public Game' }).click()
 
   const page2 = await context.newPage()
@@ -13,6 +14,7 @@ test('logout button destroys session', async ({ context }) => {
   await page2.getByRole('button', { name: 'Continue as Guest' }).click()
   await page2.getByPlaceholder('Enter your nickname').fill('test name 2')
   await page2.getByRole('button', { name: 'Join' }).click()
+  await page2.waitForSelector('#joinPublicRoom')
   await page2.getByRole('button', { name: 'Join Public Game' }).click()
   await page2.getByRole('button', { name: /^Join$/ }).click()
 

--- a/tests/pastPrompts.spec.js
+++ b/tests/pastPrompts.spec.js
@@ -20,15 +20,9 @@ test('user sees past games', async ({ page }) => {
 
 test('next page button works', async ({ page }) => {
   await page.goto('http://localhost:4000/')
-  await page.getByRole('button', { name: 'Sign In' }).click()
-  await page.getByLabel('Username:').click()
-  await page.getByLabel('Username:').fill(env.ADMIN_NAME)
-  await page.getByLabel('Password:').click()
-  await page.getByLabel('Password:').fill(env.ADMIN_PASSWORD)
-  await page
-    .locator('#loginForm')
-    .getByRole('button', { name: 'Login' })
-    .click()
+  await page.getByRole('button', { name: 'Continue as Guest' }).click()
+  await page.getByPlaceholder('Enter your nickname').fill('test')
+  await page.getByRole('button', { name: 'Join' }).click()
   await page.getByRole('button', { name: 'History' }).click()
   await page.getByRole('button', { name: 'Next' }).click()
   await page.locator('li').first().click()
@@ -39,17 +33,10 @@ test('next page button works', async ({ page }) => {
 
 test('previous page button works', async ({ page }) => {
   await page.goto('http://localhost:4000/')
-
-  await page.getByRole('button', { name: 'Sign In' }).click()
-  await page.getByLabel('Username:').click()
-  await page.getByLabel('Username:').fill(env.ADMIN_NAME)
-  await page.getByLabel('Password:').click()
-  await page.getByLabel('Password:').fill(env.ADMIN_PASSWORD)
-  await page
-    .locator('#loginForm')
-    .getByRole('button', { name: 'Login' })
-    .click()
-  await page.getByRole('button', { name: 'View History' }).click()
+  await page.getByRole('button', { name: 'Continue as Guest' }).click()
+  await page.getByPlaceholder('Enter your nickname').fill('test')
+  await page.getByRole('button', { name: 'Join' }).click()
+  await page.getByRole('button', { name: 'History' }).click()
   await page.getByRole('button', { name: 'Next' }).click()
   await page.getByRole('button', { name: 'Previous' }).click()
   await page.locator('li').first().click()

--- a/tests/pastPrompts.spec.js
+++ b/tests/pastPrompts.spec.js
@@ -1,4 +1,7 @@
 import { test, expect } from '@playwright/test'
+import { env } from 'process'
+const dotenv = require('dotenv')
+dotenv.config({ path: './config.env' })
 
 test('user sees past games', async ({ page }) => {
   await page.goto('http://localhost:4000/')
@@ -19,9 +22,9 @@ test('next page button works', async ({ page }) => {
   await page.goto('http://localhost:4000/')
   await page.getByRole('button', { name: 'Sign In' }).click()
   await page.getByLabel('Username:').click()
-  await page.getByLabel('Username:').fill('admin')
+  await page.getByLabel('Username:').fill(env.ADMIN_NAME)
   await page.getByLabel('Password:').click()
-  await page.getByLabel('Password:').fill('3l3n4010')
+  await page.getByLabel('Password:').fill(env.ADMIN_PASSWORD)
   await page
     .locator('#loginForm')
     .getByRole('button', { name: 'Login' })
@@ -29,7 +32,7 @@ test('next page button works', async ({ page }) => {
   await page.getByRole('button', { name: 'History' }).click()
   await page.getByRole('button', { name: 'Next' }).click()
   await page.locator('li').first().click()
-  await expect(
+  expect(
     await page.getByRole('button', { name: 'Back to game list' }).isVisible()
   ).toBeTruthy()
 })
@@ -39,9 +42,9 @@ test('previous page button works', async ({ page }) => {
 
   await page.getByRole('button', { name: 'Sign In' }).click()
   await page.getByLabel('Username:').click()
-  await page.getByLabel('Username:').fill('admin')
+  await page.getByLabel('Username:').fill(env.ADMIN_NAME)
   await page.getByLabel('Password:').click()
-  await page.getByLabel('Password:').fill('3l3n4010')
+  await page.getByLabel('Password:').fill(env.ADMIN_PASSWORD)
   await page
     .locator('#loginForm')
     .getByRole('button', { name: 'Login' })
@@ -50,7 +53,7 @@ test('previous page button works', async ({ page }) => {
   await page.getByRole('button', { name: 'Next' }).click()
   await page.getByRole('button', { name: 'Previous' }).click()
   await page.locator('li').first().click()
-  await expect(
+  expect(
     await page.getByRole('button', { name: 'Back to game list' }).isVisible()
   ).toBeTruthy()
 })


### PR DESCRIPTION
tests were mainly made to make sure they had navigated fully before starting the next section, and the .$() operator was removed in favor of .locator()